### PR TITLE
Handle profile

### DIFF
--- a/D365DeveloperExtensions.Core/Connection/CrmLoginForm.xaml.cs
+++ b/D365DeveloperExtensions.Core/Connection/CrmLoginForm.xaml.cs
@@ -52,6 +52,9 @@ namespace D365DeveloperExtensions.Core.Connection
         public event EventHandler ConnectionToCrmCompleted;
         #endregion
 
+        public CrmLoginForm(bool autoLogin) : this(autoLogin, null)
+        {
+        }
 
         public CrmLoginForm(bool autoLogin, string profileName)
         {
@@ -86,7 +89,10 @@ namespace D365DeveloperExtensions.Core.Connection
             // set this option to true. 
             _mgr.UseUserLocalDirectoryForConfigStore = true;
 
-            _mgr.ProfileName = _profileName;
+            if(_profileName != null)
+            {
+                _mgr.ProfileName = _profileName;
+            }
 
             _mgr.ClientId = "2ad88395-b77d-4561-9441-d0e40824f9bc";
             _mgr.RedirectUri = new Uri("app://5d3e90d6-aa8e-48a8-8f2c-58b45cc67315");

--- a/D365DeveloperExtensions.Core/Connection/CrmLoginForm.xaml.cs
+++ b/D365DeveloperExtensions.Core/Connection/CrmLoginForm.xaml.cs
@@ -34,6 +34,7 @@ namespace D365DeveloperExtensions.Core.Connection
         private bool _resetUiFlag;
 
         private readonly bool _autoLogin;
+        private readonly string _profileName;
         #endregion
 
         #region Properties
@@ -52,7 +53,7 @@ namespace D365DeveloperExtensions.Core.Connection
         #endregion
 
 
-        public CrmLoginForm(bool autoLogin)
+        public CrmLoginForm(bool autoLogin, string profileName)
         {
             InitializeComponent();
             //// Should be used for testing only.
@@ -62,6 +63,7 @@ namespace D365DeveloperExtensions.Core.Connection
             //    return true;
             //};
             _autoLogin = autoLogin;
+            _profileName = profileName;
             EnableXrmToolingLogging();
         }
 
@@ -83,6 +85,8 @@ namespace D365DeveloperExtensions.Core.Connection
             // if you are using an unmanaged client, excel for example, and need to store the config in the users local directory
             // set this option to true. 
             _mgr.UseUserLocalDirectoryForConfigStore = true;
+
+            _mgr.ProfileName = _profileName;
 
             _mgr.ClientId = "2ad88395-b77d-4561-9441-d0e40824f9bc";
             _mgr.RedirectUri = new Uri("app://5d3e90d6-aa8e-48a8-8f2c-58b45cc67315");

--- a/D365DeveloperExtensions.Core/Connection/XrmToolingConnection.xaml.cs
+++ b/D365DeveloperExtensions.Core/Connection/XrmToolingConnection.xaml.cs
@@ -468,7 +468,7 @@ namespace D365DeveloperExtensions.Core.Connection
             {
                 StatusBar.SetStatusBarValue(Resource.StatusBarMessageConnecting, vsStatusAnimation.vsStatusAnimationGeneral);
 
-                CrmLoginForm ctrl = new CrmLoginForm(_autoLogin);
+                CrmLoginForm ctrl = new CrmLoginForm(_autoLogin, SelectedProfile);
                 ctrl.ConnectionToCrmCompleted += ConnectionToCrmCompleted;
                 bool? result = ctrl.ShowDialog();
 

--- a/D365DeveloperExtensions/D365DeveloperExtensionsPackage.cs
+++ b/D365DeveloperExtensions/D365DeveloperExtensionsPackage.cs
@@ -44,7 +44,7 @@ namespace D365DeveloperExtensions
     /// </para>
     /// </remarks>
     [PackageRegistration(UseManagedResourcesOnly = true)]
-    [InstalledProductRegistration("#110", "#112", "2.0.18102.0258", IconResourceID = 400)] // Info on this package for Help/About
+    [InstalledProductRegistration("#110", "#112", "2.0.18345.1857", IconResourceID = 400)] // Info on this package for Help/About
     [ProvideMenuResource("Menus.ctmenu", 1)]
     [ProvideToolWindow(typeof(PluginDeployerHost))]
     [ProvideToolWindow(typeof(WebResourceDeployerHost))]
@@ -206,7 +206,7 @@ namespace D365DeveloperExtensions
 
         private static void ConnectToCrm()
         {
-            CrmLoginForm ctrl = new CrmLoginForm(false);
+            CrmLoginForm ctrl = new CrmLoginForm(false, "intellinsense");
             ctrl.ConnectionToCrmCompleted += CtrlOnConnectionToCrmCompleted;
             ctrl.ShowDialog();
         }

--- a/D365DeveloperExtensions/D365DeveloperExtensionsPackage.cs
+++ b/D365DeveloperExtensions/D365DeveloperExtensionsPackage.cs
@@ -206,7 +206,7 @@ namespace D365DeveloperExtensions
 
         private static void ConnectToCrm()
         {
-            CrmLoginForm ctrl = new CrmLoginForm(false, "intellinsense");
+            CrmLoginForm ctrl = new CrmLoginForm(false);
             ctrl.ConnectionToCrmCompleted += CtrlOnConnectionToCrmCompleted;
             ctrl.ShowDialog();
         }

--- a/D365DeveloperExtensions/Properties/AssemblyInfo.cs
+++ b/D365DeveloperExtensions/Properties/AssemblyInfo.cs
@@ -10,5 +10,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 [assembly: ComVisible(false)]
-[assembly: AssemblyVersion("2.0.18102.0258")]
-[assembly: AssemblyFileVersion("2.0.18102.0258")]
+[assembly: AssemblyVersion("2.0.18345.1857")]
+[assembly: AssemblyFileVersion("2.0.18345.1857")]

--- a/D365DeveloperExtensions/source.extension.vsixmanifest
+++ b/D365DeveloperExtensions/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="D365DeveloperExtensions.Jason Lattimer.ae772bae-97ff-47fa-8741-778a3c776740" Version="2.0.18102.0258" Language="en-US" Publisher="Jason Lattimer" />
+        <Identity Id="D365DeveloperExtensions.Jason Lattimer.ae772bae-97ff-47fa-8741-778a3c776740" Version="2.0.18345.1857" Language="en-US" Publisher="Jason Lattimer" />
         <DisplayName>D365 Developer Extensions</DisplayName>
         <Description xml:space="preserve">Dynamics 365 Developer Extensions for Dynamics CRM/365 Customer Engagement versions 2011+</Description>
         <MoreInfo>https://github.com/jlattimer/D365DeveloperExtensions</MoreInfo>


### PR DESCRIPTION
In CrmConnectionManager class the is the option to use ProfileName, this option is not currently used, but the extension is prepared for that because there are profile names in spkl.json configuration. This is a simple change which will simply use the profile from spkl.json in CrmConnectionManager. I believe that this is very useful for people like myself, who are having many VS opened at the same time or simply are switching between different projects and do not want to reconnect every time (autoconnect works correct for different profiles).